### PR TITLE
Update parity-db: 0.2.3 -> 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495197c078e54b8735181aa35c00a327f7f3a3cc00a1ee8c95926dd010f0ec6b"
+checksum = "2e337f62db341435f0da05b8f6b97e984ef4ea5800510cd07c2d624688c40b47"
 dependencies = [
  "blake2-rfc",
  "crc32fast",


### PR DESCRIPTION
parity-db 0.2.3 has a syntax error in its Cargo.toml file so this upgrade fixes that.

See https://github.com/paritytech/parity-db/commit/f349aa30e76f3219a90aaae99c0f3f07d994692e